### PR TITLE
ci: add release pipeline to update winget package

### DIFF
--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -13,18 +13,30 @@ jobs:
     steps:
       - name: Submit danstis.rmstale package to WinGet Community Repository
         run: |
+          $ErrorActionPreference = "Stop"
 
           $wingetPackage = "danstis.rmstale"
           $gitToken = "${{ secrets.WINGET_PAT }}"
 
           $github = Invoke-RestMethod -uri "https://api.github.com/repos/danstis/rmstale/releases"
 
-          $targetRelease = $github | Where-Object {(-not $_.draft) -and (-not $_.prerelease)} | Select -First 1
+          $targetRelease = $github | Where-Object {-not $_.draft -and -not $_.prerelease} | Select -First 1
           $installerAmd64Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_amd64.zip'} | Select -ExpandProperty browser_download_url
           $installerArm64Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_arm64.zip'} | Select -ExpandProperty browser_download_url
           $installerX86Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_386.zip'} | Select -ExpandProperty browser_download_url
           $ver = $targetRelease.tag_name.Trim("v")
 
+          if (-not $installerAmd64Url -or -not $installerArm64Url -or -not $installerX86Url -or -not $ver) {
+            Write-Error "One or more installer URLs are empty."
+          }
+
           # getting latest wingetcreate file
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          .\wingetcreate.exe update $wingetPackage --submit --version $ver --urls $installerAmd64Url $installerArm64Url $installerX86Url --token $gitToken
+          $downloadStatus = iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          if ($downloadStatus.StatusCode -ne 200) {
+            Write-Error "Failed to download wingetcreate.exe"
+          }
+          try {
+            .\wingetcreate.exe update $wingetPackage --submit --version $ver --urls $installerAmd64Url $installerArm64Url $installerX86Url --token $gitToken
+          } catch {
+            Write-Error "Failed to submit the winget package: $_"
+          }

--- a/.github/workflows/winget-submission.yml
+++ b/.github/workflows/winget-submission.yml
@@ -1,0 +1,30 @@
+name: Winget Submission
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  winget:
+    name: Publish winget package
+    runs-on: windows-latest
+    environment: winget
+    steps:
+      - name: Submit danstis.rmstale package to WinGet Community Repository
+        run: |
+
+          $wingetPackage = "danstis.rmstale"
+          $gitToken = "${{ secrets.WINGET_PAT }}"
+
+          $github = Invoke-RestMethod -uri "https://api.github.com/repos/danstis/rmstale/releases"
+
+          $targetRelease = $github | Where-Object {(-not $_.draft) -and (-not $_.prerelease)} | Select -First 1
+          $installerAmd64Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_amd64.zip'} | Select -ExpandProperty browser_download_url
+          $installerArm64Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_arm64.zip'} | Select -ExpandProperty browser_download_url
+          $installerX86Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_386.zip'} | Select -ExpandProperty browser_download_url
+          $ver = $targetRelease.tag_name.Trim("v")
+
+          # getting latest wingetcreate file
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          .\wingetcreate.exe update $wingetPackage --submit --version $ver --urls $installerAmd64Url $installerArm64Url $installerX86Url --token $gitToken


### PR DESCRIPTION
## **User description**
Fixes #188


___

## **Type**
enhancement


___

## **Description**
- Adds a new GitHub Actions workflow to automate the submission of the winget package upon a new release.
- The workflow is triggered either manually or when a new release is published.
- It specifically targets Windows environments and uses PowerShell to handle the submission process.
- This enhancement streamlines the process of updating the winget package, ensuring that the latest version is always available for users.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>winget-submission.yml</strong><dd><code>Add GitHub Actions Workflow for Winget Package Submission</code></dd></summary>
<hr>

.github/workflows/winget-submission.yml
<li>Introduces a new GitHub Actions workflow named 'Winget Submission'.<br> <li> Triggers on workflow dispatch and when a release is published.<br> <li> Defines a job to publish the winget package to the WinGet Community <br>Repository.<br> <li> Utilizes PowerShell to select the latest non-draft, non-prerelease <br>GitHub release, download the latest wingetcreate tool, and submit the <br>package.<br>


</details>
    

  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/191/files#diff-7d855962b4887ece7bc4f20d0347d84534b0ed7e681789172e45511dcc68c6e8">+30/-0</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

