### PR TITLE
fix: update output of various commands

### DIFF
--- a/rmstale.go
+++ b/rmstale.go
@@ -27,6 +27,8 @@ const usage = `Usage of rmstale:
 `
 
 func main() {
+	flag.Usage = func() { fmt.Print(usage) }
+
 	var (
 		folder  string
 		age     int
@@ -45,13 +47,18 @@ func main() {
 	flag.StringVar(&ext, "extension", "", "Filter files by extension.")
 	flag.BoolVar(&version, "v", false, "Display version information.")
 	flag.BoolVar(&version, "version", false, "Display version information.")
-	flag.Usage = func() { fmt.Print(usage) }
+
+	// Parse flags
 	flag.Parse()
 
 	defer logger.Init("rmstale", true, true, io.Discard).Close()
 	logger.SetFlags(log.Ltime)
 
-	flag.Parse()
+	// Check if no command-line arguments were provided
+	if flag.NFlag() == 0 && len(flag.Args()) == 0 {
+		flag.Usage()
+		return
+	}
 
 	if ext != "" {
 		extMsg = fmt.Sprintf(" with extension '%v'", ext)

--- a/rmstale.go
+++ b/rmstale.go
@@ -30,12 +30,12 @@ func main() {
 	flag.Usage = func() { fmt.Print(usage) }
 
 	var (
-		folder  string
-		age     int
-		confirm bool
-		ext     string
-		version bool
-		extMsg  string
+		folder      string
+		age         int
+		confirm     bool
+		ext         string
+		showVersion bool
+		extMsg      string
 	)
 	flag.StringVar(&folder, "p", os.TempDir(), "Path to check for stale files.")
 	flag.StringVar(&folder, "path", os.TempDir(), "Path to check for stale files.")
@@ -45,8 +45,8 @@ func main() {
 	flag.BoolVar(&confirm, "confirm", false, "Don't prompt for confirmation.")
 	flag.StringVar(&ext, "e", "", "Filter files by extension.")
 	flag.StringVar(&ext, "extension", "", "Filter files by extension.")
-	flag.BoolVar(&version, "v", false, "Display version information.")
-	flag.BoolVar(&version, "version", false, "Display version information.")
+	flag.BoolVar(&showVersion, "v", false, "Display version information.")
+	flag.BoolVar(&showVersion, "version", false, "Display version information.")
 
 	// Parse flags
 	flag.Parse()
@@ -64,7 +64,7 @@ func main() {
 		extMsg = fmt.Sprintf(" with extension '%v'", ext)
 	}
 
-	if version {
+	if showVersion {
 		fmt.Println(versionInfo())
 		return
 	}

--- a/rmstale.go
+++ b/rmstale.go
@@ -54,8 +54,8 @@ func main() {
 	defer logger.Init("rmstale", true, true, io.Discard).Close()
 	logger.SetFlags(log.Ltime)
 
-	// Check if no command-line arguments were provided
-	if flag.NFlag() == 0 && len(flag.Args()) == 0 {
+	// Check if no command-line arguments were provided or if an argument is provided without a '-'
+	if flag.NFlag() == 0 && len(flag.Args()) == 0 || len(flag.Args()) > 0 && flag.Arg(0)[0] != '-' {
 		flag.Usage()
 		return
 	}

--- a/rmstale.go
+++ b/rmstale.go
@@ -93,6 +93,10 @@ func versionInfo() string {
 	return fmt.Sprintf("rmstale v%v", AppVersion)
 }
 
+// procDir recursively processes a directory and removes stale files.
+// It takes the file path (fp) of the directory to process, the root folder (rootFolder) for reference,
+// the age (age) in days to determine staleness, and the file extension (ext) to filter files.
+// It returns an error if any operation fails.
 func procDir(fp, rootFolder string, age int, ext string) error {
 	// get the fileInfo for the directory
 	di, err := os.Stat(fp)
@@ -138,6 +142,8 @@ func procDir(fp, rootFolder string, age int, ext string) error {
 }
 
 // isEmpty checks if a directory is empty.
+// It returns true if the directory is empty, false otherwise.
+// An error is returned if there was a problem opening or reading the directory.
 func isEmpty(name string) (bool, error) {
 	f, err := os.Open(name)
 	if err != nil {

--- a/rmstale.go
+++ b/rmstale.go
@@ -58,7 +58,7 @@ func main() {
 	}
 
 	if version {
-		fmt.Printf("rmstale v%v\n", AppVersion)
+		fmt.Println(versionInfo())
 		return
 	}
 
@@ -79,6 +79,11 @@ func main() {
 	if err := procDir(folder, folder, age, ext); err != nil {
 		logger.Errorf("Something went wrong: %v", err)
 	}
+}
+
+// versionInfo returns the version information of the rmstale application
+func versionInfo() string {
+	return fmt.Sprintf("rmstale v%v", AppVersion)
 }
 
 func procDir(fp, rootFolder string, age int, ext string) error {

--- a/rmstale_test.go
+++ b/rmstale_test.go
@@ -307,6 +307,13 @@ func (suite *RMStateSuite) TestFilteredDirectoryProcessing() {
 	suite.True(exists(suite.oldEmptySubdir))
 }
 
+// TestVersionInfo tests the version information output
+func (suite *RMStateSuite) TestVersionInfo() {
+	expected := "rmstale v0.0.0"
+	actual := versionInfo()
+	suite.Equal(expected, actual)
+}
+
 // In order for 'go test' to run this suite, we need to create
 // a normal test function and pass our suite to suite.Run
 func TestRunSuite(t *testing.T) {


### PR DESCRIPTION
## **User description**
fixes #192, #193


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Introduced a new function `versionInfo` to standardize version information output.
- Improved command-line usage output by setting `flag.Usage` and adding a check to display it when no arguments are provided.
- Added a unit test `TestVersionInfo` to ensure the correctness of the version information output.
- Enhanced documentation for clarity and completeness.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale.go</strong><dd><code>Enhance command-line usage output and version information handling</code></dd></summary>
<hr>

rmstale.go
<li>Added a new function <code>versionInfo</code> to return version information.<br> <li> Modified the main function to use <code>flag.Usage</code> for better command-line <br>usage output.<br> <li> Implemented a check to display usage information if no command-line <br>arguments are provided.<br> <li> Enhanced documentation for <code>isEmpty</code> function.


</details>
    

  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/194/files#diff-8d2045f56d565d537deafa629d12ea2b52f0701a7366f155b4b1038745e58e4e">+21/-3</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale_test.go</strong><dd><code>Add unit test for version information output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale_test.go
<li>Added a new test <code>TestVersionInfo</code> to verify the output of the <br><code>versionInfo</code> function.


</details>
    

  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/194/files#diff-8db921908b71276932d8420d8851eb76734ed17c3f850b48510d458588e51ce7">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

