### PR TITLE
feat: add a whatif/dry run option

### DIFF
--- a/rmstale.go
+++ b/rmstale.go
@@ -184,7 +184,7 @@ func removeItem(fp, rootFolder string, dryRun bool) {
 		return
 	}
 	if dryRun {
-		logger.Infof("Dry run: '%v' would be removed...", filepath.FromSlash(fp))
+		logger.Infof("[DRY RUN] '%v' would be removed...", filepath.FromSlash(fp))
 		return
 	}
 	logger.Infof("Removing '%v'...", filepath.FromSlash(fp))


### PR DESCRIPTION
## **User description**
Fixes #186


___

## **Type**
enhancement, tests


___

## **Description**
- Introduced a dry run mode to the application, allowing users to simulate file removal without actually deleting any files. This is useful for verifying what would be deleted in a real run.
- Added a `dryRun` boolean flag that can be set via `-d` or `--dry-run` command-line options.
- Modified the `procDir` and `removeItem` functions to support dry run mode by skipping the actual file removal process if `dryRun` is true.
- Expanded the test suite to include tests for the new dry run functionality, ensuring that no files are removed when the mode is active.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale.go</strong><dd><code>Implement Dry Run Mode for Safe Operation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale.go
<li>Added a <code>dryRun</code> boolean flag to enable dry run mode where files are not <br>actually removed.<br> <li> Modified <code>procDir</code> and <code>removeItem</code> functions to accept <code>dryRun</code> as a <br>parameter and conditionally skip file removal.<br> <li> Updated flag parsing to include the <code>dryRun</code> option with <code>-d</code> and <br><code>--dry-run</code> flags.


</details>
    

  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/201/files#diff-8d2045f56d565d537deafa629d12ea2b52f0701a7366f155b4b1038745e58e4e">+13/-6</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale_test.go</strong><dd><code>Extend Tests to Cover Dry Run Mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale_test.go
<li>Extended test cases to include the <code>dryRun</code> parameter.<br> <li> Added a new test suite <code>TestDryRunOption</code> to verify that files are not <br>removed when <code>dryRun</code> is true.


</details>
    

  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/201/files#diff-8db921908b71276932d8420d8851eb76734ed17c3f850b48510d458588e51ce7">+40/-4</a>&nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

