### PR TITLE
fix: confirmation is broken

### DIFF
--- a/rmstale.go
+++ b/rmstale.go
@@ -78,11 +78,9 @@ func main() {
 		return
 	}
 
-	if !confirm && !dryRun {
-		if !prompt("WARNING: Will remove files and folders recursively below '%v'%s older than %v days.", filepath.FromSlash(folder), extMsg, age) {
-			logger.Warning("Operation not confirmed, exiting.")
-			return
-		}
+	if !confirm && !dryRun && !prompt("WARNING: Will remove files and folders recursively below '%v'%s older than %v days.", filepath.FromSlash(folder), extMsg, age) {
+		logger.Warning("Operation not confirmed, exiting.")
+		return
 	}
 
 	logger.Infof("rmstale started against folder '%v'%s for contents older than %v days.", filepath.FromSlash(folder), extMsg, age)

--- a/rmstale.go
+++ b/rmstale.go
@@ -78,9 +78,11 @@ func main() {
 		return
 	}
 
-	if !prompt("WARNING: Will remove files and folders recursively below '%v'%s older than %v days.", filepath.FromSlash(folder), extMsg, age) {
-		logger.Warning("Operation not confirmed, exiting.")
-		return
+	if !confirm && !dryRun {
+		if !prompt("WARNING: Will remove files and folders recursively below '%v'%s older than %v days.", filepath.FromSlash(folder), extMsg, age) {
+			logger.Warning("Operation not confirmed, exiting.")
+			return
+		}
 	}
 
 	logger.Infof("rmstale started against folder '%v'%s for contents older than %v days.", filepath.FromSlash(folder), extMsg, age)


### PR DESCRIPTION
## **User description**
Fixes #206, #203


___

## **Type**
bug_fix


___

## **Description**
- Enhanced the confirmation logic in `rmstale.go` to skip the confirmation prompt when either `dryRun` mode is enabled or confirmation is already provided. This improvement addresses issues where automated processes or specific scenarios required bypassing the manual confirmation step, thereby streamlining operations and avoiding unnecessary interruptions.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale.go</strong><dd><code>Enhance Confirmation Logic for File Removal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale.go
<li>Added a conditional check to only prompt for confirmation if not in <br><code>dryRun</code> mode and confirmation is not already provided.<br> <li> Ensures operation proceeds without unnecessary confirmation prompt in <br>automated or dry run scenarios.


</details>
    

  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/207/files#diff-8d2045f56d565d537deafa629d12ea2b52f0701a7366f155b4b1038745e58e4e">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

