### PR TITLE
fix: add error handling in directory check and tests


### DIFF
--- a/rmstale.go
+++ b/rmstale.go
@@ -175,12 +175,16 @@ func handleEmptyDirectory(fp string, di fs.FileInfo, age int, ext, rootFolder st
 // isEmpty checks if a directory is empty.
 // It returns true if the directory is empty, false otherwise.
 // An error is returned if there was a problem opening or reading the directory.
-func isEmpty(name string) (bool, error) {
+func isEmpty(name string) (empty bool, err error) {
 	f, err := os.Open(name)
 	if err != nil {
 		return false, err
 	}
-	defer f.Close()
+	defer func() {
+		if cerr := f.Close(); err == nil && cerr != nil {
+			err = cerr
+		}
+	}()
 
 	_, err = f.Readdirnames(1)
 	if err == io.EOF {

--- a/rmstale_test.go
+++ b/rmstale_test.go
@@ -98,7 +98,9 @@ func (suite *RMStateSuite) SetupTest() {
 
 // The TearDownTest method will be run after every test in the suite.
 func (suite *RMStateSuite) TearDownTest() {
-	os.RemoveAll(suite.rootDir)
+	if err := os.RemoveAll(suite.rootDir); err != nil {
+		suite.T().Fatal(err)
+	}
 }
 
 // TestAgeDetection tests the detection of stale files
@@ -409,10 +411,12 @@ func (suite *RMStateSuite) TestPrompt() {
 			defer func() { os.Stdin = oldStdin }()
 			r, w, _ := os.Pipe()
 			os.Stdin = r
-			go func() {
-				fmt.Fprint(w, t.response)
-				w.Close()
-			}()
+			if _, err := fmt.Fprint(w, t.response); err != nil {
+				suite.T().Fatal(err)
+			}
+			if err := w.Close(); err != nil {
+				suite.T().Fatal(err)
+			}
 
 			got := prompt(t.format, t.a...)
 			suite.Equal(t.want, got)


### PR DESCRIPTION
### **User description**
## Summary
- check error when closing directories in `isEmpty`
- propagate teardown cleanup errors in tests
- handle pipe write/close errors in prompt test

## Testing
- `go vet ./...`
- `$(go env GOPATH)/bin/staticcheck ./...`
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68439cebdd48832f80012478f91dc97a


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Propagate file close errors in `isEmpty`

- Check `RemoveAll` error in `TearDownTest`

- Handle pipe write and close errors in `TestPrompt`


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale.go</strong><dd><code>Add error check for f.Close in isEmpty</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale.go

<li>Changed <code>isEmpty</code> to use named return values<br> <li> Wrapped <code>f.Close()</code> in defer to capture close errors<br> <li> Propagates any <code>Close()</code> error when reading directory


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/254/files#diff-8d2045f56d565d537deafa629d12ea2b52f0701a7366f155b4b1038745e58e4e">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale_test.go</strong><dd><code>Add error handling in teardown and prompt tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale_test.go

<li>Verify <code>os.RemoveAll</code> error in <code>TearDownTest</code><br> <li> Check errors from <code>fmt.Fprint</code> in <code>TestPrompt</code><br> <li> Check errors when closing write-end of pipe


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/254/files#diff-8db921908b71276932d8420d8851eb76734ed17c3f850b48510d458588e51ce7">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>