### PR TITLE
docs: show default flag values

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ rm rmstale.tar.gz
 
 ### Command line flags
 
-| Flag            | Description                                                                                                        |
-| --------------- | ------------------------------------------------------------------------------------------------------------------ |
-| -a, --age       | Period in days before an item is considered stale.                                                                 |
-| -d, --dry-run   | Runs the process in dry-run mode. No files will be removed, but the tool will log the files that would be deleted. |
-| -e, --extension | Filter files for a defined file extension. This flag only applies to files, not directories.                       |
-| -p, --path      | Path to a folder to process.                                                                                       |
-| -v, --version   | Displays the version of rmstale that is currently running.                                                         |
-| -y, --confirm   | Allows for processing without confirmation prompt, useful for scheduling.                                          |
+| Flag            | Description                                                                                                                    | Default |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------- |
+| -a, --age       | Period in days before an item is considered stale.                                                                             | `0` |
+| -d, --dry-run   | Runs the process in dry-run mode. No files will be removed, but the tool will log the files that would be deleted.              | `false` |
+| -e, --extension | Filter files for a defined file extension. This flag only applies to files, not directories.                                   | *(empty)* |
+| -p, --path      | Path to a folder to process.                                                                                                    | system temp dir |
+| -v, --version   | Displays the version of rmstale that is currently running.                                                                     | `false` |
+| -y, --confirm   | Allows for processing without confirmation prompt, useful for scheduling.                                                      | `false` |
 
 ### Usage examples
 

--- a/rmstale.go
+++ b/rmstale.go
@@ -18,17 +18,19 @@ import (
 // AppVersion controls the application version number
 var AppVersion = "0.0.0"
 
-const usage = `Usage of rmstale:
-  -a, --age 		Period in days before an item is considered stale.
-  -d, --dry-run		Runs the process in dry-run mode. No files will be removed, but the tool will log the files that would be deleted.
-  -e, --extension	Filter files for a defined file extension. This flag only applies to files, not directories.
-  -p, --path		Path to a folder to process.
-  -v, --version		Displays the version of rmstale that is currently running.
-  -y, --confirm		Allows for processing without confirmation prompt, useful for scheduling.
-`
+func usage() string {
+	return fmt.Sprintf(`Usage of rmstale:
+  -a, --age             Period in days before an item is considered stale. (default %d)
+  -d, --dry-run         Runs the process in dry-run mode. No files will be removed, but the tool will log the files that would be deleted. (default %v)
+  -e, --extension       Filter files for a defined file extension. This flag only applies to files, not directories. (default %q)
+  -p, --path            Path to a folder to process. (default %s)
+  -v, --version         Displays the version of rmstale that is currently running. (default %v)
+  -y, --confirm         Allows for processing without confirmation prompt, useful for scheduling. (default %v)
+`, 0, false, "", filepath.FromSlash(os.TempDir()), false, false)
+}
 
 func main() {
-	flag.Usage = func() { fmt.Print(usage) }
+	flag.Usage = func() { fmt.Print(usage()) }
 
 	var (
 		folder      string

--- a/rmstale_test.go
+++ b/rmstale_test.go
@@ -520,6 +520,16 @@ func TestMainNoFlagsShowsUsage(t *testing.T) {
 	}
 }
 
+func TestMainHelpShowsDefaults(t *testing.T) {
+	output := usage()
+	if !strings.Contains(output, os.TempDir()) {
+		t.Fatalf("expected default path in usage output, got %q", output)
+	}
+	if !strings.Contains(output, "(default 0)") || !strings.Contains(output, "(default false)") {
+		t.Fatalf("expected default values in usage output, got %q", output)
+	}
+}
+
 func TestGetExt(t *testing.T) {
 	for _, tt := range []struct{ path, want string }{
 		{"file.txt", "txt"},


### PR DESCRIPTION
## Summary
- document default flag values in README
- show default values in CLI usage
- test help output includes defaults

## Testing
- `golangci-lint run ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843c7ad65d8832f8f3d28204fea7046