### PR TITLE
ci: set open-pull-requests-limit to 0 in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     labels:
       - "dependencies ⬆️"
       - "go 🐹"
@@ -18,6 +19,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     labels:
       - "github actions 🛠️"
       - "build 🛠️"


### PR DESCRIPTION
### **User description**
Fixes #339


___

### **PR Type**
enhancement, dependencies_⬆️


___

### **Description**
- Set `open-pull-requests-limit` to 0 for all ecosystems

- Prevent duplicate update PRs from Dependabot


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["dependabot.yml"] -- "add open-pull-requests-limit: 0" --> B["gomod ecosystem"]
  A -- "add open-pull-requests-limit: 0" --> C["github-actions ecosystem"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dependabot.yml</strong><dd><code>Set open-pull-requests-limit to 0 for ecosystems</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/dependabot.yml

<ul><li>Added <code>open-pull-requests-limit: 0</code> to <code>gomod</code> ecosystem<br> <li> Added <code>open-pull-requests-limit: 0</code> to <code>github-actions</code> ecosystem</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/340/files#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

