### PR TITLE
ci: integrate OSSign binary signing with cron-based polling for release workflow

### DIFF
--- a/.github/workflows/ossign-poll.yml
+++ b/.github/workflows/ossign-poll.yml
@@ -10,8 +10,8 @@ jobs:
     name: Check OSSign signing status
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      actions: write
+      contents: write    # upload signed release assets
+      variables: write   # clear repository variables after completion
     outputs:
       signing_complete: ${{ steps.set-complete.outputs.signing_complete }}
 
@@ -89,9 +89,9 @@ jobs:
           $github = Invoke-RestMethod -uri "https://api.github.com/repos/danstis/rmstale/releases"
 
           $targetRelease = $github | Where-Object {-not $_.draft -and -not $_.prerelease} | Select -First 1
-          $installerAmd64Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_x86_64.zip'} | Select -ExpandProperty browser_download_url
-          $installerArm64Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_arm64.zip'} | Select -ExpandProperty browser_download_url
-          $installerX86Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_i386.zip'} | Select -ExpandProperty browser_download_url
+          $installerAmd64Url = $targetRelease.assets | Where-Object {$_.name -match 'rmstale_.*_windows_x86_64.zip'} | Select -ExpandProperty browser_download_url -First 1
+          $installerArm64Url = $targetRelease.assets | Where-Object {$_.name -match 'rmstale_.*_windows_arm64.zip'} | Select -ExpandProperty browser_download_url -First 1
+          $installerX86Url = $targetRelease.assets | Where-Object {$_.name -match 'rmstale_.*_windows_i386.zip'} | Select -ExpandProperty browser_download_url -First 1
           $ver = $targetRelease.tag_name.Trim("v")
 
           if (-not $installerAmd64Url -or -not $installerArm64Url -or -not $installerX86Url -or -not $ver) {

--- a/.github/workflows/ossign-poll.yml
+++ b/.github/workflows/ossign-poll.yml
@@ -1,0 +1,106 @@
+name: OSSign Polling
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch:
+
+jobs:
+  poll:
+    name: Check OSSign signing status
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    outputs:
+      signing_complete: ${{ steps.set-complete.outputs.signing_complete }}
+
+    steps:
+      - name: Check for pending signing request
+        id: check-pending
+        run: |
+          pending_id="${{ vars.OSSIGN_PENDING_WORKFLOW_ID }}"
+          if [ -z "$pending_id" ]; then
+            echo "No pending signing request. Exiting."
+            echo "has_pending=false" >> $GITHUB_OUTPUT
+          else
+            echo "Pending workflow: $pending_id"
+            echo "has_pending=true" >> $GITHUB_OUTPUT
+            echo "workflow_id=$pending_id" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check OSSign signing status
+        if: steps.check-pending.outputs.has_pending == 'true'
+        id: ossign-check
+        uses: ossign/actions/workflow/dispatch@main
+        with:
+          username: ${{ secrets.OSSIGN_USER }}
+          token: ${{ secrets.OSSIGN_TOKEN }}
+          single_check: ${{ steps.check-pending.outputs.workflow_id }}
+
+      - name: Replace release assets with signed files
+        if: >-
+          steps.check-pending.outputs.has_pending == 'true' &&
+          steps.ossign-check.outputs.signed_artifacts != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ vars.OSSIGN_RELEASE_TAG }}
+          SIGNED_ARTIFACTS: ${{ steps.ossign-check.outputs.signed_artifacts }}
+        run: |
+          echo "$SIGNED_ARTIFACTS" | jq -c '.[]' | while IFS= read -r artifact; do
+            name=$(echo "$artifact" | jq -r '.name')
+            url=$(echo "$artifact" | jq -r '.browser_download_url')
+            curl -fsSL -o "$name" "$url"
+            gh release upload "$RELEASE_TAG" "$name" --clobber
+            echo "Replaced: $name"
+          done
+
+      - name: Set signing complete flag
+        if: >-
+          steps.check-pending.outputs.has_pending == 'true' &&
+          steps.ossign-check.outputs.signed_artifacts != ''
+        id: set-complete
+        run: echo "signing_complete=true" >> $GITHUB_OUTPUT
+
+      - name: Clear pending signing state
+        if: >-
+          steps.check-pending.outputs.has_pending == 'true' &&
+          steps.ossign-check.outputs.signed_artifacts != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh variable set OSSIGN_PENDING_WORKFLOW_ID --body ""
+          gh variable set OSSIGN_RELEASE_TAG --body ""
+
+  winget:
+    name: Publish winget package
+    runs-on: windows-latest
+    needs: poll
+    if: needs.poll.outputs.signing_complete == 'true'
+    environment: winget
+    steps:
+      - name: Submit danstis.rmstale package to WinGet Community Repository
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $wingetPackage = "danstis.rmstale"
+          $gitToken = "${{ secrets.WINGET_PAT }}"
+
+          $github = Invoke-RestMethod -uri "https://api.github.com/repos/danstis/rmstale/releases"
+
+          $targetRelease = $github | Where-Object {-not $_.draft -and -not $_.prerelease} | Select -First 1
+          $installerAmd64Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_x86_64.zip'} | Select -ExpandProperty browser_download_url
+          $installerArm64Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_arm64.zip'} | Select -ExpandProperty browser_download_url
+          $installerX86Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_i386.zip'} | Select -ExpandProperty browser_download_url
+          $ver = $targetRelease.tag_name.Trim("v")
+
+          if (-not $installerAmd64Url -or -not $installerArm64Url -or -not $installerX86Url -or -not $ver) {
+            Write-Error "One or more installer URLs are empty."
+          }
+
+          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+          try {
+            .\wingetcreate.exe update $wingetPackage --submit --version $ver --urls $installerAmd64Url $installerArm64Url $installerX86Url --token $gitToken
+          } catch {
+            Write-Error "Failed to submit the winget package: $_"
+          }

--- a/.github/workflows/ossign-poll.yml
+++ b/.github/workflows/ossign-poll.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Check OSSign signing status
         if: steps.check-pending.outputs.has_pending == 'true'
         id: ossign-check
-        uses: ossign/actions/workflow/dispatch@main
+        uses: ossign/actions/workflow/dispatch@fbf0b39466d9409f05d1efc0e58cc3e4615ac625
         with:
           username: ${{ secrets.OSSIGN_USER }}
           token: ${{ secrets.OSSIGN_TOKEN }}
@@ -80,11 +80,13 @@ jobs:
     environment: winget
     steps:
       - name: Submit danstis.rmstale package to WinGet Community Repository
+        env:
+          WINGET_PAT: ${{ secrets.WINGET_PAT }}
         run: |
           $ErrorActionPreference = "Stop"
 
           $wingetPackage = "danstis.rmstale"
-          $gitToken = "${{ secrets.WINGET_PAT }}"
+          $gitToken = $env:WINGET_PAT
 
           $github = Invoke-RestMethod -uri "https://api.github.com/repos/danstis/rmstale/releases"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,29 @@ jobs:
         with:
           args: push /wksp/bin/chocolatey/rmstale.${{ needs.tag.outputs.version }}.nupkg --source https://push.chocolatey.org/ --apikey ${{ secrets.CHOCO_KEY }}
 
+  request-signing:
+    name: Request OSSign signing
+    runs-on: ubuntu-latest
+    needs: [tag, release]
+    if: ${{ needs.tag.outputs.prerelease == '' }}
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch signing request to OSSign
+        id: dispatch
+        uses: ossign/actions/workflow/dispatch@main
+        with:
+          username: ${{ secrets.OSSIGN_USER }}
+          token: ${{ secrets.OSSIGN_TOKEN }}
+          dispatch_only: true
+
+      - name: Store pending signing state
+        run: |
+          gh variable set OSSIGN_PENDING_WORKFLOW_ID --body "${{ steps.dispatch.outputs.workflow_id }}"
+          gh variable set OSSIGN_RELEASE_TAG --body "v${{ needs.tag.outputs.version }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   sync-repo:
     name: Sync winget-pkgs repo
     runs-on: ubuntu-latest
@@ -101,35 +124,3 @@ jobs:
           exit "$status"
         env:
           GH_TOKEN: ${{ secrets.WINGET_PAT }}
-  winget:
-    name: Publish winget package
-    runs-on: windows-latest
-    needs: [release, sync-repo]
-    environment: winget
-    steps:
-      - name: Submit danstis.rmstale package to WinGet Community Repository
-        run: |
-          $ErrorActionPreference = "Stop"
-
-          $wingetPackage = "danstis.rmstale"
-          $gitToken = "${{ secrets.WINGET_PAT }}"
-
-          $github = Invoke-RestMethod -uri "https://api.github.com/repos/danstis/rmstale/releases"
-
-          $targetRelease = $github | Where-Object {-not $_.draft -and -not $_.prerelease} | Select -First 1
-          $installerAmd64Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_x86_64.zip'} | Select -ExpandProperty browser_download_url
-          $installerArm64Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_arm64.zip'} | Select -ExpandProperty browser_download_url
-          $installerX86Url = $targetRelease | Select -ExpandProperty assets -First 1 | Where-Object {$_.name -match 'rmstale_.*_windows_i386.zip'} | Select -ExpandProperty browser_download_url
-          $ver = $targetRelease.tag_name.Trim("v")
-
-          if (-not $installerAmd64Url -or -not $installerArm64Url -or -not $installerX86Url -or -not $ver) {
-            Write-Error "One or more installer URLs are empty."
-          }
-
-          # getting latest wingetcreate file
-          iwr https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
-          try {
-            .\wingetcreate.exe update $wingetPackage --submit --version $ver --urls $installerAmd64Url $installerArm64Url $installerX86Url --token $gitToken
-          } catch {
-            Write-Error "Failed to submit the winget package: $_"
-          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
     needs: [tag, release]
     if: ${{ needs.tag.outputs.prerelease == '' }}
     permissions:
-      actions: write
+      variables: write
     steps:
       - name: Dispatch signing request to OSSign
         id: dispatch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Dispatch signing request to OSSign
         id: dispatch
-        uses: ossign/actions/workflow/dispatch@main
+        uses: ossign/actions/workflow/dispatch@fbf0b39466d9409f05d1efc0e58cc3e4615ac625
         with:
           username: ${{ secrets.OSSIGN_USER }}
           token: ${{ secrets.OSSIGN_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ bin
 
 # Repo specific
 /dist
+.omc/


### PR DESCRIPTION
## Summary

- Adds an OSSign signing trigger to the release workflow that dispatches a signing request after GoReleaser publishes release assets
- Adds a new cron-based polling workflow (`ossign-poll.yml`) that checks every 30 minutes for signed files and replaces the original release assets when ready
- Moves WinGet submission to the polling workflow so manifests reference signed file URLs
- Adds `.omc/` to `.gitignore`

## Why

Windows binaries published to GitHub Releases were unsigned, which triggers SmartScreen warnings for users. OSSign provides Authenticode signing via a companion repository. The signing process is asynchronous (can take 30+ minutes), so the integration requires a trigger step and a separate polling loop.

The polling loop is designed to be light on Actions runner minutes: each cron tick exits in ~5 seconds when no signing request is active (no sleeping, no idle runners). The 30-minute wait between checks happens entirely outside GitHub Actions via the cron schedule.

## Implementation details

### `release.yml` — new `request-signing` job

Runs after the `release` job on stable releases only. Dispatches to OSSign with `dispatch_only: true` (fire-and-forget) and stores two repository variables to bridge state between workflow runs:
- `OSSIGN_PENDING_WORKFLOW_ID` — the OSSign workflow ID to poll against
- `OSSIGN_RELEASE_TAG` — the release tag to update with signed assets (e.g. `v1.2.3`)

The `winget` job has been removed from this workflow (see below).

### `.github/workflows/ossign-poll.yml` — new polling workflow

Triggered by `schedule: cron: '*/30 * * * *'` and `workflow_dispatch`.

**`poll` job** (ubuntu-latest):
1. Reads `OSSIGN_PENDING_WORKFLOW_ID` — if empty, exits immediately (~5s, negligible cost)
2. Calls OSSign `single_check` with the stored workflow ID
3. If `signed_artifacts` is returned: downloads each file and uploads to the GitHub Release with `--clobber` to replace the original unsigned assets
4. Clears both repository variables on completion

**`winget` job** (windows-latest):
- Depends on `poll` and only runs when `poll` sets `signing_complete=true`
- Contains the same WinGet submission logic as the previous `release.yml` job
- Runs after signed assets are on the release, so the submitted installer URLs point to signed files

## Prerequisites before first use

1. Add `OSSIGN_USER` and `OSSIGN_TOKEN` secrets to the repository (provided by OSSign after companion repo provisioning)
2. Create `OSSIGN_PENDING_WORKFLOW_ID` and `OSSIGN_RELEASE_TAG` as empty repository variables in repo settings (GitHub requires variables to exist before workflows can read them via `vars.*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)