### PR TITLE
fix(ci): resolve gh variable set failures due to missing git context

### DIFF
--- a/.github/workflows/ossign-poll.yml
+++ b/.github/workflows/ossign-poll.yml
@@ -69,8 +69,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh variable set OSSIGN_PENDING_WORKFLOW_ID --body ""
-          gh variable set OSSIGN_RELEASE_TAG --body ""
+          gh variable set OSSIGN_PENDING_WORKFLOW_ID --body "" --repo ${{ github.repository }}
+          gh variable set OSSIGN_RELEASE_TAG --body "" --repo ${{ github.repository }}
 
   winget:
     name: Publish winget package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,8 +94,8 @@ jobs:
 
       - name: Store pending signing state
         run: |
-          gh variable set OSSIGN_PENDING_WORKFLOW_ID --body "${{ steps.dispatch.outputs.workflow_id }}"
-          gh variable set OSSIGN_RELEASE_TAG --body "v${{ needs.tag.outputs.version }}"
+          gh variable set OSSIGN_PENDING_WORKFLOW_ID --body "${{ steps.dispatch.outputs.workflow_id }}" --repo ${{ github.repository }}
+          gh variable set OSSIGN_RELEASE_TAG --body "v${{ needs.tag.outputs.version }}" --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

- Added `--repo ${{ github.repository }}` to all `gh variable set` calls in the OSSign workflow steps
- Affected files: `.github/workflows/release.yml` and `.github/workflows/ossign-poll.yml`

## Why

The `request-signing` job in `release.yml` and the `poll` job in `ossign-poll.yml` do not include an `actions/checkout` step. Without a checked-out repository, the `gh` CLI cannot infer which repo to operate on from git context, causing the following error at runtime:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

Passing `--repo` explicitly tells `gh` which repository to target without requiring a git working tree.

## Implementation Details

- `release.yml` — "Store pending signing state" step: both `gh variable set` calls now include `--repo ${{ github.repository }}`
- `ossign-poll.yml` — "Clear pending signing state" step: both `gh variable set` calls now include `--repo ${{ github.repository }}`
- No checkout step was added; the `--repo` flag is the minimal, correct fix

## Test plan

- [x] Trigger a release to confirm the `Request OSSign signing` job completes without error
- [x] Verify `OSSIGN_PENDING_WORKFLOW_ID` and `OSSIGN_RELEASE_TAG` variables are set correctly after the job runs