### PR TITLE
fix: reject non-positive --age to prevent wiping target directory

### DIFF
--- a/rmstale.go
+++ b/rmstale.go
@@ -61,9 +61,6 @@ func main() {
 	// Parse flags
 	flag.Parse()
 
-	defer logger.Init("rmstale", true, true, io.Discard).Close()
-	logger.SetFlags(log.Ltime)
-
 	// Check if no command-line arguments were provided or if an argument is provided without a '-'
 	if flag.NFlag() == 0 && len(flag.Args()) == 0 || len(flag.Args()) > 0 && flag.Arg(0)[0] != '-' {
 		flag.Usage()
@@ -79,10 +76,14 @@ func main() {
 		return
 	}
 
-	if age == 0 {
+	if err := validateAge(age); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
 		flag.Usage()
-		return
+		os.Exit(1)
 	}
+
+	defer logger.Init("rmstale", true, true, io.Discard).Close()
+	logger.SetFlags(log.Ltime)
 
 	if !confirm && !dryRun && !prompt("WARNING: Will remove files and folders recursively below '%v'%s older than %v days.", filepath.FromSlash(folder), extMsg, age) {
 		logger.Warning("Operation not confirmed, exiting.")
@@ -99,6 +100,16 @@ func main() {
 // versionInfo returns the version information of the rmstale application
 func versionInfo() string {
 	return fmt.Sprintf("rmstale v%v", AppVersion)
+}
+
+// validateAge ensures the supplied --age is a positive integer. Any value <= 0
+// is rejected because negative ages invert the staleness comparison and cause
+// the tool to treat every file as stale (i.e. delete the entire target tree).
+func validateAge(age int) error {
+	if age <= 0 {
+		return fmt.Errorf("--age must be a positive integer (got %d)", age)
+	}
+	return nil
 }
 
 // prompt prompts the user for confirmation before proceeding.

--- a/rmstale_test.go
+++ b/rmstale_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -18,6 +19,13 @@ import (
 func init() {
 	initLogger()
 }
+
+// testBinaryPath captures os.Args[0] before any test gets a chance to clobber
+// it (TestMainVersionFlag reassigns os.Args to simulate CLI invocation).
+// exec.Command needs the full test binary path; relying on os.Args[0] at the
+// moment TestMainRejectsNonPositiveAge runs would fail if a prior test changed
+// it.
+var testBinaryPath = os.Args[0]
 
 // RMStaleSuite defines the testing suite with the following files:
 //
@@ -348,7 +356,6 @@ func (suite *RMStateSuite) TestDryRunOption() {
 	suite.True(exists(suite.oldSubdir3))
 	suite.True(exists(suite.oldEmptySubdir))
 }
-
 
 // TestPruneEmptyDirsOption tests the prune-empty-dirs option
 func (suite *RMStateSuite) TestPruneEmptyDirsOption() {
@@ -778,4 +785,93 @@ func TestIsEmptyWithDeferError(t *testing.T) {
 	if !empty {
 		t.Fatal("expected empty directory to be reported as empty")
 	}
+}
+
+// TestValidateAge ensures the age guard rejects every non-positive value so a
+// negative --age cannot silently pass through and wipe the target directory.
+// Regression test for BSOD-281.
+func TestValidateAge(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		age     int
+		wantErr bool
+	}{
+		{"positive age", 30, false},
+		{"age of one", 1, false},
+		{"zero age", 0, true},
+		{"negative age of one", -1, true},
+		{"negative age of seven", -7, true},
+		{"large negative age", -100, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateAge(tt.age)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateAge(%d) error = %v, wantErr = %v", tt.age, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestMainRejectsNonPositiveAge is the integration regression test for
+// BSOD-281: a negative or zero --age must not cause main() to descend into
+// procDir. It re-execs the test binary so the os.Exit(1) inside main() does
+// not tear down the parent test process.
+func TestMainRejectsNonPositiveAge(t *testing.T) {
+	if os.Getenv("BE_CRASHER") == "1" {
+		runCrasher(t)
+		return
+	}
+
+	for _, tt := range []struct {
+		name string
+		age  string
+	}{
+		{"negative age", "-1"},
+		{"zero age", "0"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := tempDirectory(t, "rmstale-bsod281", os.TempDir())
+			t.Cleanup(func() { os.RemoveAll(tmpDir) })
+
+			cmd := exec.Command(testBinaryPath, "-test.run=TestMainRejectsNonPositiveAge")
+			cmd.Env = append(os.Environ(),
+				"BE_CRASHER=1",
+				fmt.Sprintf("RMSTALE_TEST_AGE=%s", tt.age),
+				fmt.Sprintf("RMSTALE_TEST_DIR=%s", tmpDir),
+			)
+			out, err := cmd.CombinedOutput()
+			if err == nil {
+				t.Fatalf("expected non-zero exit code, got nil. output: %s", out)
+			}
+			if !strings.Contains(string(out), "must be a positive integer") {
+				t.Logf("subprocess output: %q (len=%d)", out, len(out))
+				t.Logf("subprocess err: %v", err)
+				t.Fatalf("expected positive-integer error message, got %q", out)
+			}
+		})
+	}
+}
+
+// runCrasher is executed inside the BE_CRASHER subprocess. It sets up a
+// controlled temp directory with a sentinel file and invokes main() with the
+// age value supplied by the parent. If main() does not exit early (i.e. it
+// descends into procDir), the sentinel file is deleted and the test fails.
+func runCrasher(t *testing.T) {
+	age := os.Getenv("RMSTALE_TEST_AGE")
+	dir := os.Getenv("RMSTALE_TEST_DIR")
+	if age == "" || dir == "" {
+		t.Fatal("crasher requires RMSTALE_TEST_AGE and RMSTALE_TEST_DIR")
+	}
+
+	sentinel := tempFile(t, "must-not-be-deleted", dir)
+
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	os.Args = []string{"rmstale", "-a", age, "-p", dir, "-y"}
+	main()
+
+	if exists(sentinel.Name()) {
+		// main() returned without calling os.Exit — guard never tripped.
+		os.Exit(2)
+	}
+	os.Exit(0)
 }


### PR DESCRIPTION
### **User description**
## Summary

Negative values for `-a/--age` silently bypassed the existing `age == 0` guard and inverted the staleness comparison in `isStale`. With `-a -1`, every file's mtime is before `time.Now() + 1 day`, so the tool deletes the entire target tree (and the rmstale binary itself if it lives there).

Closes BSOD-281.

## Fix

- New `validateAge` helper rejects any `age <= 0` with a clear error.
- `main()` prints the error to stderr, shows usage, and exits with a non-zero status instead of silently proceeding.
- Moved the existing `defer logger.Init(...).Close()` below the new validation step so `os.Exit(1)` does not skip the deferred close (gocritic `exitAfterDefer`).

## Regression coverage

- `TestValidateAge` — table-driven test for the helper (positive, zero, negative cases).
- `TestMainRejectsNonPositiveAge` — re-execs the test binary with `-a -1` and `-a 0` against a controlled temp directory, asserts the non-zero exit, the error message, and that a sentinel file is left untouched.

## Checks

- `go test ./...` (with `-race`) — pass
- `gofmt -l` — clean
- `go vet ./...` — clean
- `golangci-lint run` — 0 issues


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Add `validateAge` helper to reject non-positive `--age` values

- Move logger initialization after validation to avoid `exitAfterDefer` issue

- Add unit test `TestValidateAge` for the helper

- Add integration test `TestMainRejectsNonPositiveAge` that re-execs the binary and verifies early exit and error message


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User provides --age"] --> B["validateAge(age)"]
  B -- "age <= 0" --> C["Print error to stderr"]
  C --> D["os.Exit(1)"]
  B -- "age > 0" --> E["Proceed with stale file removal"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale.go</strong><dd><code>Add age validation and reorder logger init</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale.go

<ul><li>Added <code>validateAge</code> function that returns an error for non-positive age <br>values<br> <li> Replaced the <code>age == 0</code> guard with a call to <code>validateAge</code> and exit with <br>error message on failure<br> <li> Moved <code>defer logger.Init(...).Close()</code> after the validation step to <br>prevent <code>exitAfterDefer</code> lint warning</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/379/files#diff-8d2045f56d565d537deafa629d12ea2b52f0701a7366f155b4b1038745e58e4e">+16/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale_test.go</strong><dd><code>Add regression tests for non-positive age rejection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale_test.go

<ul><li>Added <code>TestValidateAge</code> table-driven test covering positive, zero, and <br>negative age values<br> <li> Added <code>TestMainRejectsNonPositiveAge</code> integration test that re-execs the <br>test binary with <code>-a -1</code> and <code>-a 0</code>, asserting non-zero exit and error <br>message<br> <li> Introduced <code>testBinaryPath</code> variable to capture the binary path before <br>tests modify <code>os.Args</code><br> <li> Added <code>runCrasher</code> helper to simulate the subprocess environment for the <br>integration test</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/379/files#diff-8db921908b71276932d8420d8851eb76734ed17c3f850b48510d458588e51ce7">+97/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

