### PR TITLE
fix: exit non-zero when rmstale encounters a processing error

### DIFF
--- a/rmstale.go
+++ b/rmstale.go
@@ -34,6 +34,13 @@ func usage() string {
 }
 
 func main() {
+	os.Exit(run())
+}
+
+// run contains the core CLI logic for rmstale and returns the process exit code.
+// Splitting this out of main lets tests exercise error paths without invoking
+// os.Exit, which would otherwise terminate the test binary.
+func run() int {
 	flag.Usage = func() { fmt.Print(usage()) }
 
 	var (
@@ -66,7 +73,7 @@ func main() {
 	// Check if no command-line arguments were provided or if an argument is provided without a '-'
 	if flag.NFlag() == 0 && len(flag.Args()) == 0 || len(flag.Args()) > 0 && flag.Arg(0)[0] != '-' {
 		flag.Usage()
-		return
+		return exitSuccess
 	}
 
 	if ext != "" {
@@ -75,7 +82,7 @@ func main() {
 
 	if showVersion {
 		fmt.Println(versionInfo())
-		return
+		return exitSuccess
 	}
 
 	if err := validateAge(age); err != nil {
@@ -89,15 +96,25 @@ func main() {
 
 	if !confirm && !dryRun && !prompt("WARNING: Will remove files and folders recursively below '%v'%s older than %v days.", filepath.FromSlash(folder), extMsg, age) {
 		logger.Warning("Operation not confirmed, exiting.")
-		return
+		return exitSuccess
 	}
 
 	logger.Infof("rmstale started against folder '%v'%s for contents older than %v days.", filepath.FromSlash(folder), extMsg, age)
 
 	if err := procDir(folder, folder, age, ext, dryRun, pruneEmptyDirs); err != nil {
 		logger.Errorf("Something went wrong: %v", err)
+		return exitProcessingError
 	}
+	return exitSuccess
 }
+
+// Exit codes returned by run. Processing failures (BSOD-285) return a non-zero
+// code so that wrappers, schedulers and CI steps can distinguish a successful
+// run from one in which procDir reported an error.
+const (
+	exitSuccess         = 0
+	exitProcessingError = 1
+)
 
 // versionInfo returns the version information of the rmstale application
 func versionInfo() string {

--- a/rmstale_test.go
+++ b/rmstale_test.go
@@ -623,7 +623,7 @@ func captureOutput(f func()) string {
 func TestMainVersionFlag(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	os.Args = []string{"rmstale", "-v"}
-	output := captureOutput(func() { main() })
+	output := captureOutput(func() { _ = run() })
 	if !strings.Contains(output, "rmstale v") {
 		t.Fatalf("expected version info, got %q", output)
 	}
@@ -632,7 +632,7 @@ func TestMainVersionFlag(t *testing.T) {
 func TestMainNoFlagsShowsUsage(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	os.Args = []string{"rmstale"}
-	output := captureOutput(func() { main() })
+	output := captureOutput(func() { _ = run() })
 	if !strings.Contains(output, "Usage of rmstale") {
 		t.Fatalf("expected usage output, got %q", output)
 	}
@@ -729,8 +729,12 @@ func TestMainWithExtensionMessage(t *testing.T) {
 
 	os.Args = []string{"rmstale", "-a", "30", "-e", "txt", "-y", "-d", "-p", tmpDir}
 
-	// Run main and verify extension filtering works
-	main()
+	// Run run() (rather than main) and verify extension filtering works.
+	// main() would call os.Exit and terminate the test binary, so tests must
+	// exercise the CLI logic through run() instead.
+	if code := run(); code != exitSuccess {
+		t.Fatalf("expected exit code %d on dry-run success, got %d", exitSuccess, code)
+	}
 
 	// Both files should still exist since we're in dry-run mode
 	// But the extension logic should have been exercised
@@ -739,16 +743,18 @@ func TestMainWithExtensionMessage(t *testing.T) {
 	}
 }
 
-// TestMainWithProcDirError tests main function when procDir returns an error
-func TestMainWithProcDirError(_ *testing.T) {
+// TestMainWithProcDirError tests that run() returns a non-zero exit code when
+// procDir fails (regression for BSOD-285). The previous behaviour fell off the
+// end of main() and reported success (exit code 0) to the OS even though
+// processing had failed, which broke scheduled/cron wrappers.
+func TestMainWithProcDirError(t *testing.T) {
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	os.Args = []string{"rmstale", "-a", "30", "-p", "/nonexistent/path", "-y"}
 
-	// Just verify main doesn't panic when given invalid path
-	// The error handling is internal and logged, not returned
-	main()
-
-	// Test passes if no panic occurs - the error is handled internally
+	code := run()
+	if code != exitProcessingError {
+		t.Fatalf("expected exit code %d when procDir errors, got %d", exitProcessingError, code)
+	}
 }
 
 // TestIsEmptyWithFile tests isEmpty function with a file instead of directory
@@ -847,7 +853,12 @@ func TestMainWithConfirmationDenied(t *testing.T) {
 		w.WriteString("n\n")
 	}()
 
-	output := captureOutput(func() { main() })
+	output := captureOutput(func() {
+		code := run()
+		if code != exitSuccess {
+			t.Fatalf("expected exit code %d when user denies confirmation, got %d", exitSuccess, code)
+		}
+	})
 
 	// Should contain confirmation prompt and file should still exist since user denied
 	if !strings.Contains(output, "Continue") && !strings.Contains(output, "proceed") {


### PR DESCRIPTION
### **User description**
## Summary

When `procDir` returned a non-nil error, `main()` only logged it via
`logger.Errorf` and then fell off the end of the function. Go's default
exit code of 0 was therefore reported to the OS, even though every
recursive call to `procDir` had failed. Wrappers, schedulers and CI
steps (which the README and `-y/--confirm` help text advertise the tool
as supporting) concluded that runs with processing failures had
succeeded.

Closes BSOD-285.

## Changes

- Extract the CLI logic into `run() int`. `main()` now calls
  `os.Exit(run())`, and the `procDir` error path returns `1` via the new
  `exitProcessingError` constant.
- Successful paths continue to return `0` (`exitSuccess`), preserving
  the documented success contract.
- Refactor is intentionally scoped to the reported error path; the
  usage / version / denied-confirmation paths still exit `0`, matching
  the previous behaviour for those callers.

## Tests

- `TestMainWithProcDirError` now asserts that `run()` returns
  `exitProcessingError` when given an invalid path (previously it only
  checked that `main()` did not panic).
- `TestMainWithExtensionMessage` and `TestMainWithConfirmationDenied`
  now call `run()` and assert the success exit code, because calling
  `main()` would invoke `os.Exit` and terminate the test binary.
- `TestMainVersionFlag` and `TestMainNoFlagsShowsUsage` are updated to
  call `run()` for the same reason.

## Checks

- `gofmt -w rmstale.go rmstale_test.go` — clean
- `go build ./...` — passes
- `go vet ./...` — clean
- `go test -race -count=1 ./...` — passes (1.07s)
- `go test -cover ./...` — 93.5% coverage
- `golangci-lint run ./...` — 0 issues

Manual smoke check: `rmstale -a 30 -p /nonexistent/path -y` now exits
`1`; `rmstale -v` and a successful dry-run still exit `0`.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Extract CLI logic into `run()` to control exit code

- Return exit code 1 when `procDir` fails, fixing BSOD-285

- Update tests to assert exit codes via `run()` instead of `main()`

- Add constants `exitSuccess` and `exitProcessingError`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  main["main()"] -- "calls" --> run["run()"]
  run -- "on error" --> exit1["exit code 1"]
  run -- "on success" --> exit0["exit code 0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale.go</strong><dd><code>Extract run() and return non-zero exit code on processing error</code></dd></summary>
<hr>

rmstale.go

<ul><li>Extract core CLI logic into <code>run()</code> function returning int<br> <li> Return <code>exitProcessingError</code> (1) when <code>procDir</code> returns an error<br> <li> Return <code>exitSuccess</code> (0) on all other paths (usage, version, etc.)<br> <li> Define exit code constants for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/381/files#diff-8d2045f56d565d537deafa629d12ea2b52f0701a7366f155b4b1038745e58e4e">+21/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale_test.go</strong><dd><code>Update tests to verify exit codes via run()</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale_test.go

<ul><li>Replace calls to <code>main()</code> with <code>run()</code> in tests to avoid <code>os.Exit</code><br> <li> Assert <code>run()</code> returns <code>exitSuccess</code> for version, usage, and confirmation <br>denial<br> <li> Add assertion that <code>run()</code> returns <code>exitProcessingError</code> for invalid path<br> <li> Update <code>TestMainWithProcDirError</code> to verify non-zero exit code</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/381/files#diff-8db921908b71276932d8420d8851eb76734ed17c3f850b48510d458588e51ce7">+23/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

