### PR TITLE
fix: propagate removeItem errors so partial cleanup is visible

### DIFF
--- a/rmstale.go
+++ b/rmstale.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"bufio"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -143,7 +144,10 @@ func prompt(format string, a ...any) bool {
 // procDir recursively processes a directory and removes stale files.
 // It takes the file path (fp) of the directory to process, the root folder (rootFolder) for reference,
 // the age (age) in days to determine staleness, and the file extension (ext) to filter files.
-// It returns an error if any operation fails.
+// It returns a joined error of all failures encountered while processing the
+// directory tree so partial cleanup is visible to the caller. The function
+// continues walking siblings after an error so that every failure is reported
+// rather than only the first one.
 func procDir(fp, rootFolder string, age int, ext string, dryRun, pruneEmptyDirs bool) error {
 	di, err := os.Stat(fp)
 	if err != nil {
@@ -155,17 +159,22 @@ func procDir(fp, rootFolder string, age int, ext string, dryRun, pruneEmptyDirs 
 		return err
 	}
 
+	var errs []error
 	for _, item := range infos {
 		if item.IsDir() {
 			if err := procDir(path.Join(fp, item.Name()), rootFolder, age, ext, dryRun, pruneEmptyDirs); err != nil {
-				return err
+				errs = append(errs, err)
 			}
-		} else {
-			processFile(item, fp, rootFolder, age, ext, dryRun)
+		} else if err := processFile(item, fp, rootFolder, age, ext, dryRun); err != nil {
+			errs = append(errs, err)
 		}
 	}
 
-	return handleEmptyDirectory(fp, di, age, ext, rootFolder, dryRun, pruneEmptyDirs)
+	if err := handleEmptyDirectory(fp, di, age, ext, rootFolder, dryRun, pruneEmptyDirs); err != nil {
+		errs = append(errs, err)
+	}
+
+	return errors.Join(errs...)
 }
 
 // getDirectoryContents retrieves the contents of a directory.
@@ -186,13 +195,18 @@ func getDirectoryContents(fp string) ([]fs.FileInfo, error) {
 }
 
 // processFile processes a file to determine if it should be removed.
-func processFile(item fs.FileInfo, fp, rootFolder string, age int, ext string, dryRun bool) {
+// It returns any error from the underlying removal so the caller can
+// aggregate failures across the directory tree.
+func processFile(item fs.FileInfo, fp, rootFolder string, age int, ext string, dryRun bool) error {
 	if isStale(item, age) && matchExt(item.Name(), ext) {
-		removeItem(path.Join(fp, item.Name()), rootFolder, dryRun)
+		return removeItem(path.Join(fp, item.Name()), rootFolder, dryRun)
 	}
+	return nil
 }
 
 // handleEmptyDirectory handles the removal of an empty directory if it is stale.
+// It returns any error from the underlying removal so the caller can
+// aggregate failures across the directory tree.
 func handleEmptyDirectory(fp string, di fs.FileInfo, age int, ext, rootFolder string, dryRun, pruneEmptyDirs bool) error {
 	empty, err := isEmpty(fp)
 	if err != nil {
@@ -203,7 +217,7 @@ func handleEmptyDirectory(fp string, di fs.FileInfo, age int, ext, rootFolder st
 		// The extension filter makes directory removal conservative by default to avoid deleting
 		// directory structures when only certain file types are being cleaned up.
 		if pruneEmptyDirs || (isStale(di, age) && ext == "") {
-			removeItem(fp, rootFolder, dryRun)
+			return removeItem(fp, rootFolder, dryRun)
 		}
 	}
 	return nil
@@ -236,19 +250,24 @@ func isStale(fi os.FileInfo, age int) bool {
 }
 
 // removeItem removes an item from the filesystem.
-func removeItem(fp, rootFolder string, dryRun bool) {
+// It returns the error from os.Remove when removal fails so callers can
+// aggregate and surface partial-failure to the user. The error is also
+// logged via the existing logger.Errorf to preserve the current log format.
+func removeItem(fp, rootFolder string, dryRun bool) error {
 	if fp == rootFolder {
 		logger.Infof("Not removing folder '%v' as it is the root folder...\n", filepath.FromSlash(fp))
-		return
+		return nil
 	}
 	if dryRun {
 		logger.Infof("[DRY RUN] '%v' would be removed...", filepath.FromSlash(fp))
-		return
+		return nil
 	}
 	logger.Infof("Removing '%v'...", filepath.FromSlash(fp))
 	if err := os.Remove(fp); err != nil {
 		logger.Errorf("%v", err)
+		return err
 	}
+	return nil
 }
 
 // getExt returns the file extension of the presented path.

--- a/rmstale_test.go
+++ b/rmstale_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -157,6 +158,7 @@ func (suite *RMStateSuite) TestFileRemoval() {
 		directory string
 		dryRun    bool
 		want      bool
+		wantErr   bool
 	}{
 		{
 			name:      "Test with a file",
@@ -164,6 +166,7 @@ func (suite *RMStateSuite) TestFileRemoval() {
 			directory: suite.rootDir,
 			dryRun:    false,
 			want:      false,
+			wantErr:   false,
 		},
 		{
 			name:      "Test with an empty folder",
@@ -171,6 +174,7 @@ func (suite *RMStateSuite) TestFileRemoval() {
 			directory: suite.rootDir,
 			dryRun:    false,
 			want:      false,
+			wantErr:   false,
 		},
 		{
 			name:      "Test with a non-empty folder",
@@ -178,6 +182,7 @@ func (suite *RMStateSuite) TestFileRemoval() {
 			directory: suite.rootDir,
 			dryRun:    false,
 			want:      true,
+			wantErr:   true,
 		},
 		{
 			name:      "Test when given the root folder",
@@ -185,10 +190,12 @@ func (suite *RMStateSuite) TestFileRemoval() {
 			directory: suite.rootDir,
 			dryRun:    false,
 			want:      true,
+			wantErr:   false,
 		},
 	} {
 		suite.Run(t.name, func() {
-			removeItem(t.filename, t.directory, t.dryRun)
+			err := removeItem(t.filename, t.directory, t.dryRun)
+			suite.Equal(t.wantErr, err != nil)
 			got := exists(t.filename)
 			suite.Equal(t.want, got)
 		})
@@ -269,6 +276,39 @@ func (suite *RMStateSuite) TestProcDirErrors() {
 			suite.Equal(t.wantErr, (err != nil))
 		})
 	}
+}
+
+// TestRemoveItemReturnsErrorForMissingPath verifies that removeItem surfaces
+// the underlying os.Remove error instead of swallowing it.
+func (suite *RMStateSuite) TestRemoveItemReturnsErrorForMissingPath() {
+	missing := filepath.Join(suite.rootDir, "does-not-exist")
+	err := removeItem(missing, suite.rootDir, false)
+	suite.NotNil(err, "removeItem should return the os.Remove error for a missing path")
+}
+
+// TestProcessFilePropagatesRemoveError verifies that processFile returns the
+// error produced by removeItem so the caller can aggregate failures.
+func (suite *RMStateSuite) TestProcessFilePropagatesRemoveError() {
+	info := fileInfo(suite.T(), suite.oldFile1.Name())
+	setAge(suite.oldFile1.Name(), suite.age+4) // satisfy isStale on the info
+	// Use a non-existent parent directory so path.Join(fp, info.Name())
+	// resolves to a path that os.Remove cannot find.
+	err := processFile(info, filepath.Join(suite.rootDir, "missing-parent"), suite.rootDir, suite.age, "", false)
+	suite.NotNil(err, "processFile should propagate the removeItem error")
+}
+
+// TestHandleEmptyDirectoryPropagatesRemoveError verifies that handleEmptyDirectory
+// returns the error produced by removeItem so the caller can aggregate failures.
+func (suite *RMStateSuite) TestHandleEmptyDirectoryPropagatesRemoveError() {
+	// An empty stale directory under a non-existent parent: handleEmptyDirectory
+	// will still reach the removeItem branch (pruneEmptyDirs=true) and os.Remove
+	// will fail because the path does not exist.
+	tmpDir := tempDirectory(suite.T(), "staleEmpty", suite.rootDir)
+	setAge(tmpDir, suite.age+4)
+	missing := filepath.Join(tmpDir, "missing-empty-dir")
+
+	err := handleEmptyDirectory(missing, fileInfo(suite.T(), tmpDir), suite.age, "", tmpDir, false, true)
+	suite.NotNil(err, "handleEmptyDirectory should propagate the removeItem error")
 }
 
 // TestDirectoryProcessing tests the running the entire process over a directory


### PR DESCRIPTION
### **User description**
## Summary

`removeItem` previously logged `os.Remove` failures and returned nothing, leaving callers unable to detect partial failure. This change is the plumbing half of BSOD-286 so a follow-up (BSOD-285) can convert the surfaced error into a non-zero exit code.

### Changes

- `removeItem` now returns the `os.Remove` error (keeping the existing per-item `logger.Errorf` so log format is unchanged).
- `processFile` propagates that error instead of discarding it.
- `handleEmptyDirectory` propagates the error instead of discarding it.
- `procDir` aggregates failures with `errors.Join` and continues walking siblings so every failure surfaces to `main()` instead of only the first.
- `main()` plumbing is unchanged — `procDir`'s joined error is already passed back through the existing `logger.Errorf` branch.

### Tests

- Updated `TestFileRemoval` to assert the new error return value.
- Added `TestRemoveItemReturnsErrorForMissingPath`, `TestProcessFilePropagatesRemoveError`, and `TestHandleEmptyDirectoryPropagatesRemoveError` to cover the new contract directly.

```
$ go test ./...
ok  	github.com/danstis/rmstale	0.037s
$ golangci-lint run ./...
0 issues.
$ go vet ./...
$ gofmt -l .
(none)
```

### Known risks

- `procDir` now collects all per-item errors instead of returning at the first failure. Behaviour change is intentional and matches the issue's "aggregate in procDir (e.g. errors.Join)" guidance.
- The aggregation of multiple `removeItem` failures inside a single `procDir` call is covered by code review; an end-to-end filesystem test was not added because deterministically making `os.Remove` fail for several items in one walk is not reliable cross-platform without races.

Refs BSOD-286


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Propagate `removeItem` errors so partial cleanup is visible to callers

- `removeItem` now returns the `os.Remove` error instead of swallowing it

- `processFile` and `handleEmptyDirectory` propagate the error upward

- `procDir` aggregates all failures with `errors.Join` and continues walking siblings

- Add tests for error propagation in `removeItem`, `processFile`, and `handleEmptyDirectory`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  removeItem["removeItem returns error"] -- "propagates" --> processFile["processFile"]
  removeItem -- "propagates" --> handleEmptyDirectory["handleEmptyDirectory"]
  processFile -- "returns error" --> procDir["procDir"]
  handleEmptyDirectory -- "returns error" --> procDir
  procDir -- "aggregates via errors.Join" --> main["main (unchanged)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale.go</strong><dd><code>Propagate removeItem errors through call chain</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale.go

<ul><li>Added <code>errors</code> import for error aggregation<br> <li> Changed <code>removeItem</code> to return the <code>os.Remove</code> error instead of logging <br>and discarding it<br> <li> Updated <code>processFile</code> and <code>handleEmptyDirectory</code> to return the error from <br><code>removeItem</code><br> <li> Modified <code>procDir</code> to collect errors from subdirectory processing, file <br>processing, and empty directory handling, then return a joined error <br>via <code>errors.Join</code><br> <li> Updated doc comments to reflect new error propagation behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/382/files#diff-8d2045f56d565d537deafa629d12ea2b52f0701a7366f155b4b1038745e58e4e">+30/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale_test.go</strong><dd><code>Add tests for error propagation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale_test.go

<ul><li>Extended <code>TestFileRemoval</code> to assert the error return value of <br><code>removeItem</code><br> <li> Added <code>TestRemoveItemReturnsErrorForMissingPath</code> to verify error surface <br>for missing paths<br> <li> Added <code>TestProcessFilePropagatesRemoveError</code> to confirm <code>processFile</code> <br>propagates the error<br> <li> Added <code>TestHandleEmptyDirectoryPropagatesRemoveError</code> to confirm <br><code>handleEmptyDirectory</code> propagates the error</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/382/files#diff-8db921908b71276932d8420d8851eb76734ed17c3f850b48510d458588e51ce7">+41/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

