### PR TITLE
docs: document trust model and security considerations for ModTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Features](#features)
 - [Install instructions](#install-instructions)
 - [Usage instructions](#usage-instructions)
+- [Trust model / Security](#trust-model--security)
 - [Contribution](#contribution)
 - [Release Process](#release-process)
 - [License](#license)
@@ -134,6 +135,22 @@ rmstale --age 30 --path ~/Downloads --dry-run
 ```
 
 Any errors encountered during the deletion process (e.g., permission issues) will be logged.
+
+## Trust model / Security
+
+rmstale decides whether a file or directory is stale from its modification time (`ModTime`) as reported by the operating system. This metadata is **trusted but not verified**: on every supported platform the file owner can change it freely using tools like `touch -d`, `os.Chtimes`, PowerShell's `LastWriteTime`, or the file properties dialog. Nothing rmstale reads about a file is cryptographically signed or tamper-evident.
+
+In practice this means:
+
+- A file that should be removed can be **pinned** past the cleanup window by setting its `ModTime` to the future (e.g. `touch -d "2099-01-01" file`).
+- Conversely, a file can be **forced into deletion** by back-dating its `ModTime`, which also lets an empty parent directory be pruned on the next run.
+
+Recommendations for operators running rmstale against shared or untrusted directories (CI runners, scratch storage, multi-tenant `/tmp` directories, HPC workspaces, etc.):
+
+- Run rmstale as a **single, dedicated user** that owns the directories being cleaned up. Treat that user's `ModTime` writes as the only ones you trust.
+- Run rmstale from a **privileged context** (e.g. a scheduled task, cron job, or service account) so that any tampering by other users with write access to the metadata cannot bypass the policy.
+- Avoid running rmstale against directories writable by users whose files you would not want to keep or delete; the `ModTime` it sees is the one those users set.
+- Use `--dry-run` first when pointing rmstale at a new path to confirm the age threshold and ownership assumptions match your expectations.
 
 ## Contribution
 


### PR DESCRIPTION
### **User description**
Adds a new "Trust model / Security" section to the README that explains rmstale trusts the OS-reported `ModTime`, that this metadata is user-tamperable on every supported platform, and recommends operators run rmstale as a privileged user against directories owned by the same user. Includes a TOC entry for the new section.

This is a documentation-only change addressing the last option from BSOD-283 (the other proposed mitigations — e.g. refusing future-dated `ModTime` — are out of scope here and will be tracked separately if pursued).

Refs: BSOD-283


___

### **PR Type**
Documentation


___

### **Description**
- Add "Trust model / Security" section to README

- Explain `ModTime` trust model and tampering risks

- Outline operator recommendations for secure usage

- Add Table of Contents link for the new section


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add trust model and security section to README</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added a new "Trust model / Security" section explaining that <code>ModTime</code> <br>is trusted but not verified, can be tampered by the file owner, and <br>provides recommendations for operators in shared or untrusted <br>environments.<br> <li> Added a Table of Contents entry for the new section.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/387/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

