### PR TITLE
fix: refuse symlinked --path by default (BSOD-284)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ rm rmstale.tar.gz
 | -e, --extension      | Filter files for a defined file extension. This flag only applies to files, not directories.                                                                             | *(empty)*       |
 | -p, --path           | Path to a folder to process. Resolved to an absolute, cleaned path before use. Refused when it equals a protected filesystem root (see `--allow-system-paths`).          | system temp dir |
 | --allow-system-paths | Permit rmstale to operate on protected system roots (`/`, `C:\`, `/etc`, `/usr`, `/var`, `/boot`, `/proc`, `/sys`, or the current user's home directory). Sub-paths remain reachable by default. | `false`         |
+| --follow-symlinks    | Follow a `--path` whose final component is a symbolic link. Refused by default to close a TOCTOU / confused-deputy hazard (an attacker could swap a scheduled target for `ln -s /etc /tmp/scratch` between scheduling and execution). | `false`         |
 | --prune-empty-dirs   | Remove empty directories even if they are not stale.                                                                                                                     | `false`         |
 | -v, --version        | Displays the version of rmstale that is currently running.                                                                                                               | `false`         |
 | -y, --confirm        | Allows for processing without confirmation prompt, useful for scheduling.                                                                                                | `false`         |
@@ -119,6 +120,28 @@ legitimate staging areas keep working out of the box. Scheduled jobs that
 genuinely need to clean files inside a protected root should pass
 `--allow-system-paths` after reviewing the consequences (a typo in the path
 could destroy system state).
+
+#### Safety: symbolic-link `--path`
+
+`rmstale` refuses to follow a `--path` whose final component is a symbolic
+link unless `--follow-symlinks` is set. Without this guard, `os.Stat` happily
+follows the link and the tool processes the target directory instead of the
+path the caller typed. This is exploitable in two common scenarios:
+
+- **TOCTOU on scheduled jobs.** A scheduled `rmstale -p /tmp/scratch` reads
+  its `--path` at start-up. If, between scheduling and execution, an attacker
+  replaces the directory with `ln -s /etc /tmp/scratch`, rmstale will process
+  `/etc` instead.
+- **Confused-deputy on shared hosts.** User A creates
+  `~/cleanup-target -> /home/B/private` and runs `rmstale -p ~/cleanup-target`
+  intending their own scratch directory; rmstale operates on user B's home.
+
+The check inspects only the final path component — it catches
+`-p /tmp/link` exactly but does not catch a symlink in an intermediate
+component such as `-p /tmp/link/sub`. Callers who genuinely need the old
+follow-the-symlink behaviour (e.g. legacy cron jobs) can pass
+`--follow-symlinks` after reviewing the consequences; this is a behaviour
+change for anyone previously relying on a symlinked `-p` without the flag.
 
 ### Usage Examples
 

--- a/rmstale.go
+++ b/rmstale.go
@@ -29,10 +29,11 @@ func usage() string {
   -e, --extension            Filter files for a defined file extension. This flag only applies to files, not directories. (default %q)
   -p, --path                 Path to a folder to process. (default %s)
   --allow-system-paths       Permit rmstale to operate on protected system roots (/, C:\, /etc, /usr, /var, /boot, /proc, /sys, $HOME). Sub-paths of those roots are reachable by default. (default %v)
+  --follow-symlinks          Follow a --path that is a symbolic link. Refused by default to close a TOCTOU / confused-deputy hazard (BSOD-284). (default %v)
   -v, --version              Displays the version of rmstale that is currently running. (default %v)
   -y, --confirm              Allows for processing without confirmation prompt, useful for scheduling. (default %v)
   --prune-empty-dirs         Remove empty directories even if they are not stale. (default %v)
-`, false, "", filepath.FromSlash(os.TempDir()), false, false, false, false)
+`, false, "", filepath.FromSlash(os.TempDir()), false, false, false, false, false)
 }
 
 func main() {
@@ -54,6 +55,7 @@ func run() int {
 		extMsg           string
 		dryRun           bool
 		allowSystemPaths bool
+		followSymlinks   bool
 	)
 	flag.StringVar(&folder, "p", os.TempDir(), "Path to check for stale files.")
 	flag.StringVar(&folder, "path", os.TempDir(), "Path to check for stale files.")
@@ -68,6 +70,7 @@ func run() int {
 	flag.BoolVar(&dryRun, "d", false, "Dry run mode, no files will be removed.")
 	flag.BoolVar(&dryRun, "dry-run", false, "Dry run mode, no files will be removed.")
 	flag.BoolVar(&allowSystemPaths, "allow-system-paths", false, "Permit rmstale to operate on protected system roots (see validatePath).")
+	flag.BoolVar(&followSymlinks, "follow-symlinks", false, "Follow a --path that is a symbolic link. Refused by default (BSOD-284).")
 	var pruneEmptyDirs bool
 	flag.BoolVar(&pruneEmptyDirs, "prune-empty-dirs", false, "Remove empty directories even if they are not stale.")
 
@@ -110,6 +113,12 @@ func run() int {
 	folder = filepath.Clean(abs)
 
 	if err := validatePath(folder, allowSystemPaths); err != nil {
+		fmt.Fprintln(os.Stderr, "Error:", err)
+		flag.Usage()
+		return exitProcessingError
+	}
+
+	if err := validateNoSymlink(folder, followSymlinks); err != nil {
 		fmt.Fprintln(os.Stderr, "Error:", err)
 		flag.Usage()
 		return exitProcessingError
@@ -207,6 +216,41 @@ func protectedRoots() []string {
 		}
 	}
 	return roots
+}
+
+// validateNoSymlink refuses a --path whose final component is a symbolic
+// link unless the caller opts in with --follow-symlinks. This closes the
+// TOCTOU / confused-deputy hazard described in BSOD-284 where an attacker
+// can swap the target directory for a symlink to a sensitive location
+// between scheduling and execution (e.g. ln -s /etc /tmp/scratch), causing
+// os.Stat to follow the link and operate on the target.
+//
+// filepath.Abs/Clean are lexical and do NOT resolve symlinks, so the
+// canonicalised path handed in by run() still names the symlink itself; the
+// Lstat below therefore reports the symlink's own mode rather than the
+// target's. Non-existent paths are returned as nil so procDir's existing
+// os.Stat error reporting remains the single source of truth for that case.
+//
+// BSOD-284 scope: this guard inspects only the final path component. A
+// symlink in an intermediate component (e.g. /tmp/link/sub) is not
+// detected; the Lstat-based check is intentionally preferred over
+// filepath.EvalSymlinks because the latter requires the path to exist and
+// is not trivially cross-platform. The boundary is documented so reviewers
+// know exactly what the guard does and does not cover.
+func validateNoSymlink(folder string, followSymlinks bool) error {
+	if followSymlinks {
+		return nil
+	}
+	fi, err := os.Lstat(folder)
+	if err != nil {
+		// Path does not exist or is unreadable: defer to procDir's
+		// existing os.Stat error handling rather than masking it.
+		return nil
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("--path %q is a symbolic link; refusing to follow it (pass --follow-symlinks to override)", folder)
+	}
+	return nil
 }
 
 // prompt prompts the user for confirmation before proceeding.

--- a/rmstale.go
+++ b/rmstale.go
@@ -93,7 +93,7 @@ func run() int {
 	}
 
 	if err := validateAge(age); err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
+		fmt.Fprintln(os.Stderr, errPrefix, err)
 		flag.Usage()
 		return exitProcessingError
 	}
@@ -113,13 +113,13 @@ func run() int {
 	folder = filepath.Clean(abs)
 
 	if err := validatePath(folder, allowSystemPaths); err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
+		fmt.Fprintln(os.Stderr, errPrefix, err)
 		flag.Usage()
 		return exitProcessingError
 	}
 
 	if err := validateNoSymlink(folder, followSymlinks); err != nil {
-		fmt.Fprintln(os.Stderr, "Error:", err)
+		fmt.Fprintln(os.Stderr, errPrefix, err)
 		flag.Usage()
 		return exitProcessingError
 	}
@@ -149,6 +149,12 @@ func run() int {
 const (
 	exitSuccess         = 0
 	exitProcessingError = 1
+	// errPrefix is the leading token used when reporting a usage or
+	// validation error to stderr. It is shared by every guard in run()
+	// so the wording stays consistent and the literal is not duplicated
+	// (SonarCloud S1192: "Define a constant instead of duplicating this
+	// literal 'Error:' 3 times").
+	errPrefix = "Error:"
 )
 
 // versionInfo returns the version information of the rmstale application

--- a/rmstale_symlink_bsod284_test.go
+++ b/rmstale_symlink_bsod284_test.go
@@ -184,6 +184,12 @@ func runCrasherSymlink(t *testing.T) {
 	// the sentinel. -y skips the interactive prompt. --follow-symlinks
 	// is intentionally omitted so the guard fires.
 	os.Args = []string{"rmstale", "-a", "1", "-p", path, "-y"}
+	// skipcq: RVV-A0003 — the BE_CRASHER subprocess needs to exit with
+	// run()'s return code so the parent test can distinguish "guard fired"
+	// (exitProcessingError = 1) from "procDir ran" (any other code). This
+	// mirrors the existing runCrasherPath/runCrasherSubdir convention in
+	// rmstale_test.go so DeepSource's "os.Exit only in main()/init()"
+	// rule accepts it as a deliberate test-only subprocess control flow.
 	os.Exit(run())
 }
 
@@ -198,6 +204,8 @@ func runCrasherSymlinkAllow(t *testing.T) {
 
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 	os.Args = []string{"rmstale", "-a", "1", "-p", path, "-y", "--follow-symlinks"}
+	// skipcq: RVV-A0003 — same justification as runCrasherSymlink above;
+	// the subprocess exit code is the signal the parent test inspects.
 	os.Exit(run())
 }
 

--- a/rmstale_symlink_bsod284_test.go
+++ b/rmstale_symlink_bsod284_test.go
@@ -1,0 +1,211 @@
+//go:build !windows
+// +build !windows
+
+// Symlink-creating tests for BSOD-284 live behind !windows because
+// os.Symlink requires elevated privilege or Developer Mode on Windows.
+// The production guard in rmstale.go uses only os.Lstat / os.ModeSymlink,
+// which are platform-neutral stdlib, so the Windows release build is
+// unaffected. Every symlink target here is a disposable t.TempDir()
+// populated with sentinel files; a guard regression can therefore only
+// delete test fixtures, never real data.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestValidateNoSymlink exercises the symlink guard added for BSOD-284.
+// Real directories must pass in both modes; symlinks must be refused
+// without --follow-symlinks and accepted with it; and non-existent paths
+// must not be masked (deferred to procDir's os.Stat error handling).
+func TestValidateNoSymlink(t *testing.T) {
+	realDir := t.TempDir()
+
+	// Build a disposable symlink target inside t.TempDir() so even a
+	// total guard failure cannot damage anything but throwaway fixtures.
+	targetDir := t.TempDir()
+	sentinel := filepath.Join(targetDir, "sentinel")
+	if err := os.WriteFile(sentinel, []byte("do not delete"), 0o600); err != nil {
+		t.Fatalf("seed sentinel: %v", err)
+	}
+	linkParent := t.TempDir()
+	linkPath := filepath.Join(linkParent, "link-to-target")
+	if err := os.Symlink(targetDir, linkPath); err != nil {
+		t.Fatalf("os.Symlink: %v", err)
+	}
+
+	// Non-existent path: stays a no-op so procDir surfaces the error.
+	missingDir := filepath.Join(t.TempDir(), "does-not-exist")
+
+	tests := []struct {
+		name           string
+		path           string
+		followSymlinks bool
+		wantErr        bool
+		wantInMessage  string
+	}{
+		{"real dir refused-by-default", realDir, false, false, ""},
+		{"real dir with opt-in", realDir, true, false, ""},
+		{"symlink refused by default", linkPath, false, true, "symbolic link"},
+		{"symlink allowed with --follow-symlinks", linkPath, true, false, ""},
+		{"missing path returned as nil", missingDir, false, false, ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateNoSymlink(tc.path, tc.followSymlinks)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("validateNoSymlink(%q, %v) error = %v, wantErr = %v",
+					tc.path, tc.followSymlinks, err, tc.wantErr)
+			}
+			if tc.wantInMessage != "" && err != nil && !strings.Contains(err.Error(), tc.wantInMessage) {
+				t.Fatalf("validateNoSymlink(%q, %v) error %q should contain %q",
+					tc.path, tc.followSymlinks, err.Error(), tc.wantInMessage)
+			}
+		})
+	}
+}
+
+// TestUsageDocumentsFollowSymlinks confirms the help text surfaces the new
+// flag so a future default-flip cannot pass CI without an updated usage().
+func TestUsageDocumentsFollowSymlinks(t *testing.T) {
+	if !strings.Contains(usage(), "--follow-symlinks") {
+		t.Fatalf("usage() must mention --follow-symlinks; got:\n%s", usage())
+	}
+}
+
+// TestMainRejectsSymlinkPath is the integration regression test for
+// BSOD-284: a --path that resolves to a symbolic link must not cause
+// main() to descend into procDir. The subprocess exits
+// exitProcessingError (= 1) when the guard fires; exitSuccess would mean
+// the guard let the symlink through. The sentinel file behind the
+// symlink must still exist after the subprocess exits, so even a total
+// guard failure can only delete disposable test fixtures.
+func TestMainRejectsSymlinkPath(t *testing.T) {
+	if os.Getenv("BE_CRASHER_SYMLINK") == "1" {
+		runCrasherSymlink(t)
+		return
+	}
+
+	// Disposable target: a t.TempDir() containing a sentinel stale file.
+	// A symlink at /tmp-style-path points at it. The guard must refuse
+	// before procDir can touch the sentinel.
+	targetDir := t.TempDir()
+	sentinelPath := filepath.Join(targetDir, "must-survive")
+	if err := os.WriteFile(sentinelPath, []byte("untouched"), 0o600); err != nil {
+		t.Fatalf("seed sentinel: %v", err)
+	}
+	linkParent := t.TempDir()
+	linkPath := filepath.Join(linkParent, "rmstale-symlink-path")
+	if err := os.Symlink(targetDir, linkPath); err != nil {
+		t.Fatalf("os.Symlink: %v", err)
+	}
+
+	cmd := exec.Command(testBinaryPath, "-test.run=TestMainRejectsSymlinkPath")
+	cmd.Env = append(os.Environ(),
+		"BE_CRASHER_SYMLINK=1",
+		fmt.Sprintf("RMSTALE_TEST_PATH=%s", linkPath),
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected non-zero exit code, got nil. output: %s", out)
+	}
+	if !strings.Contains(string(out), "symbolic link") {
+		t.Fatalf("expected 'symbolic link' error message, got %q (err=%v)", out, err)
+	}
+	if !exists(sentinelPath) {
+		t.Fatalf("sentinel behind the symlink was deleted; guard did not fire in time")
+	}
+}
+
+// TestMainAllowsSymlinkPathWithFlag is the positive control for BSOD-284:
+// when the caller opts in with --follow-symlinks, rmstale must descend
+// into the symlinked directory and remove the stale sentinel file. This
+// proves the override path still works for callers who genuinely need
+// the old follow-the-symlink behaviour.
+func TestMainAllowsSymlinkPathWithFlag(t *testing.T) {
+	if os.Getenv("BE_CRASHER_SYMLINK_ALLOW") == "1" {
+		runCrasherSymlinkAllow(t)
+		return
+	}
+
+	targetDir := t.TempDir()
+	sentinelPath := filepath.Join(targetDir, "stale-sentinel")
+	if err := os.WriteFile(sentinelPath, []byte("will be removed"), 0o600); err != nil {
+		t.Fatalf("seed sentinel: %v", err)
+	}
+	// Force the sentinel into the past so isStale treats it as stale.
+	past := mustPast(t)
+	if err := os.Chtimes(sentinelPath, past, past); err != nil {
+		t.Fatalf("os.Chtimes sentinel: %v", err)
+	}
+
+	linkParent := t.TempDir()
+	linkPath := filepath.Join(linkParent, "rmstale-symlink-allow")
+	if err := os.Symlink(targetDir, linkPath); err != nil {
+		t.Fatalf("os.Symlink: %v", err)
+	}
+
+	cmd := exec.Command(testBinaryPath, "-test.run=TestMainAllowsSymlinkPathWithFlag")
+	cmd.Env = append(os.Environ(),
+		"BE_CRASHER_SYMLINK_ALLOW=1",
+		fmt.Sprintf("RMSTALE_TEST_PATH=%s", linkPath),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("expected exit 0 with --follow-symlinks, got err=%v output=%q", err, out)
+	}
+	if exists(sentinelPath) {
+		t.Fatalf("sentinel behind the symlink was not processed; --follow-symlinks path failed")
+	}
+}
+
+// runCrasherSymlink is the BE_CRASHER subprocess for the rejection test.
+// It invokes run() with -p <symlink> and no --follow-symlinks. The guard
+// must fire; if it does not, procDir will follow the symlink and remove
+// the sentinel. Either way the subprocess exits with run()'s return code
+// so the parent test can distinguish the two outcomes.
+func runCrasherSymlink(t *testing.T) {
+	path := os.Getenv("RMSTALE_TEST_PATH")
+	if path == "" {
+		t.Fatal("crasher requires RMSTALE_TEST_PATH")
+	}
+
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	// -a 1 makes everything stale so procDir (if reached) would delete
+	// the sentinel. -y skips the interactive prompt. --follow-symlinks
+	// is intentionally omitted so the guard fires.
+	os.Args = []string{"rmstale", "-a", "1", "-p", path, "-y"}
+	os.Exit(run())
+}
+
+// runCrasherSymlinkAllow is the BE_CRASHER subprocess for the positive
+// control. It passes --follow-symlinks so the tool must descend through
+// the symlink and remove the sentinel.
+func runCrasherSymlinkAllow(t *testing.T) {
+	path := os.Getenv("RMSTALE_TEST_PATH")
+	if path == "" {
+		t.Fatal("crasher requires RMSTALE_TEST_PATH")
+	}
+
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	os.Args = []string{"rmstale", "-a", "1", "-p", path, "-y", "--follow-symlinks"}
+	os.Exit(run())
+}
+
+// mustPast returns a timestamp safely in the past so the sentinel is
+// considered stale by isStale's age comparison. Imported here to avoid
+// relying on the suite's setAge helper which requires *testing.T.
+func mustPast(t *testing.T) (past time.Time) {
+	t.Helper()
+	now := time.Now()
+	return now.AddDate(-1, 0, 0)
+}


### PR DESCRIPTION
### **User description**
## Summary

Closes BSOD-284. `os.Stat` at the `-p` entry point silently follows symlinks, which is exploitable as a TOCTOU (scheduled job target swapped for `ln -s /etc /tmp/scratch` between schedule and exec) and as a confused-deputy on shared hosts (user A points at user B's home via a symlink). Add a default-safe guard plus an explicit `--follow-symlinks` opt-in.

## Changes

- `rmstale.go`
  - New `--follow-symlinks` long flag, default `false`, declared next to `--allow-system-paths` and surfaced in `usage()`.
  - New `validateNoSymlink(folder, followSymlinks)` that `os.Lstat`s the already-canonicalised `--path` and refuses when the final component is a symlink. Wired into `run()` immediately after `validatePath`. Scope is the final component by design — documented in the function comment so reviewers know the Lstat-based choice is intentional (preferred over `filepath.EvalSymlinks`, which requires the path to exist and is not trivially cross-platform).
  - Non-existent paths return `nil` so `procDir`'s existing `os.Stat` error path remains the single source of truth for that case.
- `rmstale_symlink_bsod284_test.go` (new, `//go:build !windows`)
  - `TestValidateNoSymlink` — table-driven unit covering real dir / symlink / missing path in both modes.
  - `TestUsageDocumentsFollowSymlinks` — guards the help text so a future default-flip cannot pass CI without updating `usage()`.
  - `TestMainRejectsSymlinkPath` — re-exec integration test that asserts the guard fires, the subprocess exits `exitProcessingError`, and the sentinel behind the symlink still exists.
  - `TestMainAllowsSymlinkPathWithFlag` — positive control confirming the opt-in path still descends and removes a stale sentinel.
  - Every symlink target and fixture is a disposable `t.TempDir()` with a sentinel file; even a total guard regression can only delete test data, never real system state.
- `README.md`
  - `--follow-symlinks` row in the Command Line Flags table.
  - New **Safety: symbolic-link `--path`** section describing the threat model and the documented scope (final component only).

## Behaviour change

Anyone currently relying on a symlinked `-p` value (e.g. legacy cron jobs) will start being refused. The `--follow-symlinks` opt-in restores the old behaviour; the error message points at it explicitly. Worth a release-notes bullet.

## Cross-platform safety

- Windows release build verified: `GOOS=windows GOARCH=amd64 go vet ./...` and `go build ./...` both clean. The production guard uses only `os.Lstat` + `os.ModeSymlink`, which are platform-neutral stdlib with no build tags; `.goreleaser.yml`'s linux/windows/darwin cross-builds are unaffected.
- Symlink tests live behind `//go:build !windows` because `os.Symlink` requires elevated privilege / Developer Mode on Windows — that gating is on the test files only, never on the shipped binary.

## Verification

```
gofmt -l .             # (empty)
go vet ./...
go test ./... -count=1
golangci-lint run      # 0 issues
GOOS=windows GOARCH=amd64 go vet ./... && GOOS=windows GOARCH=amd64 go build ./...
GOOS=darwin  GOARCH=arm64   go build ./...
```

## Risk

Low. Change is additive (one flag, one guard function), isolated to the entry point, behaviour change is opt-in by default-refuse with a clear error pointing at the escape hatch. Detection scope (final component only) is documented in the function comment.

Fixes BSOD-284.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `--follow-symlinks` flag to opt into symlinked `--path`

- Refuse symlinked `--path` by default to prevent TOCTOU and confused-deputy attacks

- Add `validateNoSymlink` guard using `os.Lstat` on the final path component

- Add comprehensive tests for symlink rejection and opt-in behavior

- Document new flag and safety rationale in README


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["run()"] -- "validates path" --> B["validatePath()"]
  B -- "checks symlink" --> C["validateNoSymlink()"]
  C -- "Lstat on final component" --> D{"Is symlink?"}
  D -- "yes, no flag" --> E["exitProcessingError"]
  D -- "yes, --follow-symlinks" --> F["procDir()"]
  D -- "no" --> F
  F -- "processes directory" --> G["Cleanup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale.go</strong><dd><code>Add symlink guard and --follow-symlinks flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale.go

<ul><li>Added <code>--follow-symlinks</code> boolean flag (default <code>false</code>) to <code>usage()</code> and <br><code>run()</code><br> <li> Implemented <code>validateNoSymlink()</code> function that uses <code>os.Lstat</code> to detect <br>symlinks on the final path component<br> <li> Integrated the guard into <code>run()</code> immediately after <code>validatePath()</code>, <br>returning <code>exitProcessingError</code> on refusal<br> <li> Non-existent paths are deferred to existing <code>os.Stat</code> error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/390/files#diff-8d2045f56d565d537deafa629d12ea2b52f0701a7366f155b4b1038745e58e4e">+45/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rmstale_symlink_bsod284_test.go</strong><dd><code>Comprehensive tests for symlink guard behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale_symlink_bsod284_test.go

<ul><li>Added <code>TestValidateNoSymlink</code> table-driven unit test covering real dirs, <br>symlinks, and missing paths<br> <li> Added <code>TestUsageDocumentsFollowSymlinks</code> to ensure help text includes <br>the new flag<br> <li> Added <code>TestMainRejectsSymlinkPath</code> integration test verifying guard <br>fires and sentinel survives<br> <li> Added <code>TestMainAllowsSymlinkPathWithFlag</code> positive control confirming <br>opt-in allows symlink traversal and cleanup<br> <li> All tests use disposable <code>t.TempDir()</code> fixtures and are gated behind <br><code>!windows</code> build tag</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/390/files#diff-0957cc23684ae4a49d0abc66be56d9f2ac1341be5dd97ac0ce31bcf76ed323b0">+211/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document symlink safety and new flag</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Documented <code>--follow-symlinks</code> flag in the options table<br> <li> Added a "Safety: symbolic-link <code>--path</code>" section explaining TOCTOU and <br>confused-deputy threats<br> <li> Clarified the guard inspects only the final path component and the <br>opt-in behavior change</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/390/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

