### PR TITLE
fix: goreleaser ldflags and doc/nuspec metadata

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ builds:
       - windows
       - darwin
     ldflags:
-      - -s -w -X main.AppVersion=={{ .Version }}
+      - -s -w -X main.AppVersion={{ .Version }}
     binary: rmstale
 
 archives:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository contains `rmstale`, a small Go command line tool that removes st
 
 ## Coding Style
 
-- Use Go 1.24 or newer.
+- Use Go 1.25 or newer.
 - Format all Go code with `gofmt -w` before committing.
 - Check code with `golangci-lint` to ensure code quality.
 - Stick to the standard Go style and keep the code cross-platform.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Feedback, issues, and contributions are welcome! For bugs, issues, or feature re
 
 Want to contribute? Please:
 - Fork the repo and clone it locally
-- Use Go 1.24 or above
+- Use Go 1.25 or above
 - Format code with `gofmt -w` and check with `golangci-lint`
 - Add or update tests (`go test ./...`)
 - Follow the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines

--- a/rmstale.nuspec
+++ b/rmstale.nuspec
@@ -7,11 +7,11 @@
     <packageSourceUrl>https://github.com/danstis/rmstale</packageSourceUrl>
     <owners>Dan Anstis</owners>
     <title>rmstale</title>
-    <authors>Dan Ansits</authors>
+    <authors>Dan Anstis</authors>
     <projectUrl>https://github.com/danstis/rmstale</projectUrl>
-    <licenseUrl>https://github.com/danstis/rmstale/blob/master/LICENSE.txt</licenseUrl>
+    <licenseUrl>https://github.com/danstis/rmstale/blob/main/LICENSE.txt</licenseUrl>
     <projectSourceUrl>https://github.com/danstis/rmstale</projectSourceUrl>
-    <docsUrl>https://github.com/danstis/rmstale/blob/master/README.md</docsUrl>
+    <docsUrl>https://github.com/danstis/rmstale/blob/main/README.md</docsUrl>
     <bugTrackerUrl>https://github.com/danstis/rmstale/issues</bugTrackerUrl>
     <tags>rmstale delete stale</tags>
     <summary>rmstale removes stale files.</summary>


### PR DESCRIPTION
### **User description**
## Summary
- Fix `.goreleaser.yml` ldflags which injected a stray `=` into `main.AppVersion`, producing `rmstale v=1.2.3` instead of `rmstale v1.2.3` in every release build.
- Fix stale Go version references in README.md/AGENTS.md (1.24 → 1.25, matching `go.mod`) and nuspec metadata (author typo "Ansits" → "Anstis", `master` → `main` branch links).

## Test plan
- [x] `go test ./...` passes
- [x] `golangci-lint run` clean
- [x] `gofmt -l .` clean
- [x] Verified locally that the ldflags fix produces `rmstale v1.2.3` instead of `rmstale v=1.2.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fix goreleaser ldflags to remove stray `=` from version string

- Update Go version references from 1.24 to 1.25 in README and AGENTS

- Correct author typo and branch links in `rmstale.nuspec`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A[".goreleaser.yml"] -- "fix: remove double = in ldflags" --> B["Correct AppVersion"]
  C["README.md"] -- "docs: Go 1.24 → 1.25" --> D["Updated version references"]
  E["AGENTS.md"] -- "docs: Go 1.24 → 1.25" --> D
  F["rmstale.nuspec"] -- "fix: author typo and branch links" --> G["master → main"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.goreleaser.yml</strong><dd><code>Fix stray `=` in goreleaser ldflags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.goreleaser.yml

<ul><li>Removed a stray <code>=</code> from the <code>-X main.AppVersion</code> ldflag, changing <code>=={{ </code><br><code>.Version }}</code> to <code>={{ .Version }}</code> to fix the version string format in <br>release builds.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/392/files#diff-42e26dc67aed8aa3edb2472b4403288c1699fb6dc47419b9a475f0f224fe4689">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rmstale.nuspec</strong><dd><code>Fix author typo and branch links in nuspec</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

rmstale.nuspec

<ul><li>Fixed author name typo: <code>Ansits</code> → <code>Anstis</code>.<br> <li> Updated <code>licenseUrl</code> and <code>docsUrl</code> from <code>master</code> branch to <code>main</code> branch to <br>avoid dead links.</ul>


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/392/files#diff-4431ad72ddb74d9ce3545a43ab492ee088a48d92a70282bc4b2bf7a313423843">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update Go version reference to 1.25</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

- Updated minimum Go version from 1.24 to 1.25 to match `go.mod`.


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/392/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AGENTS.md</strong><dd><code>Update Go version reference to 1.25</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

AGENTS.md

- Updated recommended Go version from 1.24 to 1.25 to match `go.mod`.


</details>


  </td>
  <td><a href="https://github.com/danstis/rmstale/pull/392/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

